### PR TITLE
require active record before rake in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+require 'sinatra/activerecord'
 require 'sinatra/activerecord/rake'
 
 task :environment do


### PR DESCRIPTION
I was getting the error, ActiveRecord connection not established. After I included the line 'require 'sinatra/activerecord' in Rakefile, 

the error was fixed.
